### PR TITLE
Option to disable debug information

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,0 @@
-cmake-utils
-Copyright 2021 Michael Beckh
-
-This product includes software developed by
-Michael Beckh (https://github.com/mbeckh/cmake-utils).

--- a/README.md
+++ b/README.md
@@ -120,5 +120,4 @@ Add one or more external tools within Visual Studio with the following settings:
     Set CMake variable `Python_EXECUTABLE` to file path if interpreter is not found automatically.
 
 ## License
-The code is released under the Apache License Version 2.0. Please see [LICENSE](LICENSE) for details and
-[NOTICE](NOTICE) for the required information when using llamalog in your own work.
+The code is released under the Apache License Version 2.0. Please see [LICENSE](LICENSE) for details.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ Modules for building projects using [CMake](https://cmake.org/).
 
 -   Optional user overrides are read from `cmake-utils/UserSettings.cmake` and `${CMAKE_SOURCE_DIR}/cmake/UserSettings.cmake`.
 
+-   Setting CMake variable `CMU_DISABLE_DEBUG_INFORMATION` to `true` skips generation of debug information and PDB
+    to speed up builds when debug information is not required (e.g. in some CI scenarios).
+
 ## Changes to Build
 -   Enables CMake option `BUILD_TESTING` if a project is at the top level (`PROJECT_IS_TOP_LEVEL`).
 

--- a/modules/settings/_shared.cmake
+++ b/modules/settings/_shared.cmake
@@ -110,8 +110,8 @@ function(z_cmake_utils_settings_shared)
     # Warnings
     add_compile_options("$<$<COMPILE_LANGUAGE:C,CXX>:/W4;/wd4373;$<$<CONFIG:Release>:/WX>>")
 
-    # Compiler behavior
-    add_compile_options("$<$<COMPILE_LANGUAGE:C,CXX>:/nologo;/bigobj;/diagnostics:caret;/utf-8>")
+    # Compiler behavior (/MP is required by CodeQL scanning on Github)
+    add_compile_options("$<$<COMPILE_LANGUAGE:C,CXX>:/nologo;/bigobj;/diagnostics:caret;/utf-8;/MP>")
 
     #
     # Linker options

--- a/modules/settings/vcpkg.cmake
+++ b/modules/settings/vcpkg.cmake
@@ -42,5 +42,5 @@ add_compile_options("$<$<COMPILE_LANGUAGE:C,CXX>:/Z7>"
 # Linker options
 #
 
-# Debug information
+# Debug information (always added, does NOT evaluate CMU_DISABLE_DEBUG_INFORMATION because result might be cached and re-used by different builds)
 add_link_options(/DEBUG:FULL)


### PR DESCRIPTION
- Option CMU_DISABLE_DEBUG_INFORMATION to disable generation of debug information and PDB
- Re-add compiler option /MP for CodeQL
- License cleanup